### PR TITLE
fix: error parsing on /authenticate endpoint

### DIFF
--- a/src/app/authenticate/route.ts
+++ b/src/app/authenticate/route.ts
@@ -58,10 +58,11 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
 
   if (!response.ok) {
     let errorResponse;
+    let responseClone = response.clone();
     try {
       errorResponse = await response.json();
     } catch {
-      errorResponse = await response.text();
+      errorResponse = await responseClone.text();
     }
 
     console.error(
@@ -141,10 +142,11 @@ export const POST = async (req: NextRequest): Promise<NextResponse> => {
 
   if (!response.ok) {
     let errorResponse;
+    let responseClone = response.clone();
     try {
       errorResponse = await response.json();
     } catch {
-      errorResponse = await response.text();
+      errorResponse = await responseClone.text();
     }
 
     console.error(


### PR DESCRIPTION
issue was caused trying to read the body of a Response object twice