### PR TITLE
fix: require nonce for implicit flow

### DIFF
--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -99,6 +99,20 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
     (response_type as string | string[]).toString()
   ).split(" ");
 
+  // require nonce for implicit flow
+  if (
+    response_types.includes("id_token") &&
+    !response_types.includes("code") &&
+    !nonce
+  ) {
+    return errorValidationClient(
+      "invalid_request",
+      "A nonce is required when using the OIDC implicit flow.",
+      "nonce",
+      req.url
+    );
+  }
+
   for (const response_type of response_types) {
     if (!Object.keys(OIDCResponseTypeMapping).includes(response_type)) {
       return errorValidationClient(


### PR DESCRIPTION
<img width="651" alt="Screenshot 2023-08-09 at 12 28 40 PM" src="https://github.com/worldcoin/world-id-sign-in/assets/29718876/fb3493af-dd9d-43d3-ac2d-1fc0a7abe609">

shows this error when attempting to use implicit flow (response type `id_token` or `id_token token`) and a nonce is not given