### PR TITLE
Update nonce requirement for OIDC

### DIFF
--- a/src/api-helpers/utils.ts
+++ b/src/api-helpers/utils.ts
@@ -4,19 +4,19 @@ import { OIDCErrorCodes } from "./errors";
 
 type BodySource = "query" | "body" | "formData";
 
-export const validateRequestSchema = async <T>({
+export const validateRequestSchema = async <T extends yup.Schema>({
   schema,
   req,
   bodySource = "body",
 }: {
-  schema: yup.Schema<any>;
+  schema: T;
   req: NextRequest;
   bodySource?: BodySource;
 }): Promise<
-  | { isValid: true; parsedParams: T; errorResponse?: null }
+  | { isValid: true; parsedParams: yup.InferType<T>; errorResponse?: null }
   | { isValid: false; parsedParams?: null; errorResponse: NextResponse }
 > => {
-  let parsedParams: T;
+  let parsedParams: yup.InferType<typeof schema>;
   let rawParams: Record<string, string> = {};
 
   try {

--- a/src/app/authenticate/route.ts
+++ b/src/app/authenticate/route.ts
@@ -3,20 +3,20 @@ import { NextResponse } from "next/server";
 import { DEVELOPER_PORTAL } from "@/consts";
 import * as yup from "yup";
 import { validateRequestSchema } from "@/api-helpers/utils";
+import { ValidationMessage } from "@/types";
 
 const schema = yup.object({
-  proof: yup.string().required("This attribute is required."),
-  nullifier_hash: yup.string().required("This attribute is required."),
-  merkle_root: yup.string().required("This attribute is required."),
-  credential_type: yup.string().required("This attribute is required."),
-  client_id: yup.string().required("This attribute is required."),
-  nonce: yup.string().required("This attribute is required."), // NOTE: While technically not required by the OIDC spec, we require it as a security best practice
+  proof: yup.string().required(ValidationMessage.Required),
+  nullifier_hash: yup.string().required(ValidationMessage.Required),
+  merkle_root: yup.string().required(ValidationMessage.Required),
+  credential_type: yup.string().required(ValidationMessage.Required),
+  client_id: yup.string().required(ValidationMessage.Required),
+  nonce: yup.string().required(ValidationMessage.Required), // NOTE: While technically not required by the OIDC spec, we require it as a security best practice
   scope: yup.string().required("The openid scope is always required."), // NOTE: Content verified in the Developer Portal
   state: yup.string(),
-  response_type: yup.string().required("This attribute is required."), // NOTE: Content verified in the Developer Portal
-  redirect_uri: yup.string().required("This attribute is required."), // NOTE: Content verified in the Developer Portal
+  response_type: yup.string().required(ValidationMessage.Required), // NOTE: Content verified in the Developer Portal
+  redirect_uri: yup.string().required(ValidationMessage.Required), // NOTE: Content verified in the Developer Portal
 });
-type ParamsType = yup.InferType<typeof schema>;
 
 /**
  * Receives the ZKP from the frontend, verifies with Developer Portal and redirects the user.
@@ -26,12 +26,11 @@ type ParamsType = yup.InferType<typeof schema>;
  * @returns
  */
 export const POST = async (req: NextRequest): Promise<NextResponse> => {
-  const { parsedParams, isValid, errorResponse } =
-    await validateRequestSchema<ParamsType>({
-      schema,
-      req,
-      bodySource: "formData",
-    });
+  const { parsedParams, isValid, errorResponse } = await validateRequestSchema({
+    schema,
+    req,
+    bodySource: "formData",
+  });
 
   if (!isValid) {
     return errorResponse;

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -1,28 +1,125 @@
 import { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { DEVELOPER_PORTAL } from "@/consts";
-import { OIDCResponseTypeMapping } from "@/types";
+import { ValidationMessage, FlowType, OIDCResponseTypeMapping } from "@/types";
 import { errorValidationClient } from "@/api-helpers/errors";
+import * as yup from "yup";
+import { validateRequestSchema } from "@/api-helpers/utils";
 
 const SUPPORTED_SCOPES = ["openid", "profile", "email"];
 
+// NOTE: List of valid response types for the code flow
+// Source: https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth:~:text=Authorization%20Code%20Flow%2C-,this%20value%20is%20code.,-client_id
+const CODE_FLOW_RESPONSE_TYPES = ["code"] as const;
+
+// NOTE: List of valid response types for the implicit flow
+// Source: https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth:~:text=this%20value%20is%20id_token%C2%A0token%20or%20id_token
+const IMPLICIT_FLOW_RESPONSE_TYPES = ["id_token token", "id_token"] as const;
+
+// NOTE: List of valid response types for the hybrid flow
+// Source: https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth:~:text=this%20value%20is%20code%C2%A0id_token%2C%20code%C2%A0token%2C%20or%20code%C2%A0id_token%C2%A0token.
+const HYBRID_FLOW_RESPONSE_TYPES = [
+  "code id_token",
+  "code token",
+  "code id_token token",
+] as const;
+
+const RESPONSE_TYPES = [
+  ...CODE_FLOW_RESPONSE_TYPES,
+  ...IMPLICIT_FLOW_RESPONSE_TYPES,
+  ...HYBRID_FLOW_RESPONSE_TYPES,
+];
+
+type ResponseType =
+  | (typeof HYBRID_FLOW_RESPONSE_TYPES)[number]
+  | (typeof IMPLICIT_FLOW_RESPONSE_TYPES)[number]
+  | (typeof CODE_FLOW_RESPONSE_TYPES)[number];
+
+function checkFlowType(responseType: string) {
+  if (HYBRID_FLOW_RESPONSE_TYPES.some((type) => type === responseType)) {
+    return FlowType.Hybrid;
+  }
+
+  if (CODE_FLOW_RESPONSE_TYPES.some((type) => type === responseType)) {
+    return FlowType.AuthorizationCode;
+  }
+
+  if (IMPLICIT_FLOW_RESPONSE_TYPES.some((type) => type === responseType)) {
+    return FlowType.Implicit;
+  }
+
+  return "Unknown Flow";
+}
+
+const schema = yup.object({
+  response_type: yup
+    .string()
+    .strict()
+    .required(ValidationMessage.Required)
+    .test({
+      name: "is-valid-response-type",
+      message: "Invalid response type.",
+      test: (value) => {
+        const response_types = decodeURIComponent(value) as ResponseType;
+
+        if (!RESPONSE_TYPES.includes(response_types as ResponseType)) {
+          return false;
+        }
+
+        return true;
+      },
+    }),
+
+  client_id: yup.string().strict().required(ValidationMessage.Required),
+  redirect_uri: yup.string().strict().required(ValidationMessage.Required),
+
+  scope: yup
+    .string()
+    .strict()
+    .test({
+      name: "is-valid-scope",
+      message: "The requested scope is invalid, unknown, or malformed.",
+      test: (value) => {
+        if (!value) {
+          return true;
+        }
+
+        const scopes = decodeURIComponent(value).split(" ");
+
+        for (const scope of scopes) {
+          if (!SUPPORTED_SCOPES.includes(scope)) {
+            return false;
+          }
+        }
+
+        return true;
+      },
+    }),
+
+  state: yup.string(),
+
+  nonce: yup.string().when("response_type", {
+    // NOTE: we only require a nonce for the implicit flow
+    is: (value: ResponseType) =>
+      checkFlowType(decodeURIComponent(value)) === FlowType.Implicit,
+    then: (field) => field.required(ValidationMessage.Required),
+  }),
+});
+
 // FIXME: should we add a CSRF token to the request?
 export const GET = async (req: NextRequest): Promise<NextResponse> => {
-  const inputParams = Object.fromEntries(req.nextUrl.searchParams.entries());
+  const { parsedParams, isValid, errorResponse } = await validateRequestSchema({
+    schema,
+    req,
+    bodySource: "formData",
+  });
 
-  for (const attr of ["response_type", "client_id", "redirect_uri"]) {
-    if (!inputParams[attr]) {
-      return errorValidationClient(
-        "invalid_request",
-        "This attribute is required.",
-        attr,
-        req.url
-      );
-    }
+  if (!isValid) {
+    return errorResponse;
   }
 
   const { response_type, client_id, redirect_uri, scope, state, nonce } =
-    inputParams;
+    parsedParams;
 
   let url: URL | undefined;
   try {
@@ -97,31 +194,28 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
 
   const response_types = decodeURIComponent(
     (response_type as string | string[]).toString()
-  ).split(" ");
+  );
 
-  // require nonce for implicit flow
-  if (
-    !nonce &&
-    !response_types.includes("code") &&
-    response_types.includes("id_token")
-  ) {
+  if (!RESPONSE_TYPES.includes(response_types as ResponseType)) {
+    return errorValidationClient(
+      "invalid",
+      `Invalid response type: ${response_types}. Available types: ${RESPONSE_TYPES.join(
+        " | "
+      )}`,
+      "response_type",
+      req.url
+    );
+  }
+
+  // NOTE: Require nonce for implicit flow
+  // Source: https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest:~:text=as%20the%20hostname.-,nonce,REQUIRED,-.%20String%20value%20used
+  if (!nonce && checkFlowType(response_types) === FlowType.Implicit) {
     return errorValidationClient(
       "invalid_request",
       "A nonce is required when using the OIDC implicit flow.",
       "nonce",
       req.url
     );
-  }
-
-  for (const response_type of response_types) {
-    if (!Object.keys(OIDCResponseTypeMapping).includes(response_type)) {
-      return errorValidationClient(
-        "invalid",
-        `Invalid response type: ${response_type}.`,
-        "response_type",
-        req.url
-      );
-    }
   }
 
   const params = new URLSearchParams({

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -111,7 +111,7 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
   const { parsedParams, isValid, errorResponse } = await validateRequestSchema({
     schema,
     req,
-    bodySource: "formData",
+    bodySource: "query",
   });
 
   if (!isValid) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,3 +17,13 @@ export interface IAuthorizeRequest {
   scope?: string;
   state?: string;
 }
+
+export enum ValidationMessage {
+  Required = "This attribute is required",
+}
+
+export enum FlowType {
+  AuthorizationCode,
+  Implicit,
+  Hybrid,
+}

--- a/tests/e2e/authorize.test.ts
+++ b/tests/e2e/authorize.test.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { GET as handlerAuthorizeRoute } from "@/app/authorize/route";
+
+const AUTHORIZE_MOCK = {
+  response_type: "id_token token",
+  client_id: "client_id",
+  redirect_uri: "redirect_uri",
+  scope: "openid profile",
+  state: "state",
+  nonce: "nonce",
+};
+
+describe("Authorize test", () => {
+  test("Throws error when nonce not exists for implicit flow", async () => {
+    const params = new URLSearchParams({
+      ...AUTHORIZE_MOCK,
+      nonce: "",
+    } as any);
+
+    const req = new NextRequest(
+      `http://localhost/authorize?${params.toString()}`
+    );
+
+    const res = await handlerAuthorizeRoute(req);
+    expect(res.status).toBe(302);
+  });
+});


### PR DESCRIPTION
- Add `response_type` values arrays for each flow.
- Add helper (`checkFlowType`) to detect flow type
- Add checks for nonce (now it's required if the flow type is implicit)
- Add validating with `yup` for authorize route
  - @paolodamico I've made the required checks in a yup schema, but also left the old params checks in the code below. Do we need both of them or we should left one of them? We can simplify yup validation schema and validate manually below. Or we can validate everything on the params side with yup and remove manual checks.  
  
- Improve typing of validateRequestSchema. Now it infers a type from schema from arguments. Passing generic type is not required anymore (but possible).
- Add enum for common error messages. 
- Add test. 