### PR TITLE
Authorize tests

### DIFF
--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -99,7 +99,6 @@ const schema = yup.object({
     }),
 });
 
-// FIXME: should we add a CSRF token to the request?
 export const GET = async (req: NextRequest): Promise<NextResponse> => {
   const { parsedParams, isValid, errorResponse } = await validateRequestSchema({
     schema,

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -69,7 +69,7 @@ const schema = yup.object({
 
   nonce: yup.string().when("response_type", {
     // NOTE: we only require a nonce for the implicit flow
-    is: (value: ResponseType) =>
+    is: (value: string) =>
       checkFlowType(decodeURIComponent(value)) === OIDCFlowType.Implicit,
     then: (field) => field.required(ValidationMessage.Required),
   }),

--- a/tests/__mocks__/authenticate.mock.ts
+++ b/tests/__mocks__/authenticate.mock.ts
@@ -1,3 +1,5 @@
+import { OIDCFlowType, OIDCResponseType } from "@/types";
+
 export const AUTHENTICATE_MOCK: {
   [key: string]: string;
   response_type: string;
@@ -24,3 +26,24 @@ export const AUTHENTICATE_MOCK: {
   nullifier_hash:
     "0x2978b7ab28667fc641e0a38af57b6d177592d268a6d97aec19205a97bf456f23",
 };
+
+export const AUTHORIZE_CODE_RESPONSE_TYPES = [OIDCResponseType.Code];
+
+export const IMPLICIT_RESPONSE_TYPES = [
+  `${OIDCResponseType.IdToken}`,
+  `${OIDCResponseType.IdToken} ${OIDCResponseType.Token}`,
+  `${OIDCResponseType.Token} ${OIDCResponseType.IdToken}`,
+];
+
+export const HYBRID_RESPONSE_TYPES = [
+  `${OIDCResponseType.Code} ${OIDCResponseType.IdToken}`,
+  `${OIDCResponseType.IdToken} ${OIDCResponseType.Code}`,
+  `${OIDCResponseType.Code} ${OIDCResponseType.Token}`,
+  `${OIDCResponseType.Token} ${OIDCResponseType.Code}`,
+  `${OIDCResponseType.Code} ${OIDCResponseType.IdToken} ${OIDCResponseType.Token}`,
+  `${OIDCResponseType.Code} ${OIDCResponseType.Token} ${OIDCResponseType.IdToken}`,
+  `${OIDCResponseType.Token} ${OIDCResponseType.Code} ${OIDCResponseType.IdToken}`,
+  `${OIDCResponseType.Token} ${OIDCResponseType.IdToken} ${OIDCResponseType.Code}`,
+  `${OIDCResponseType.IdToken} ${OIDCResponseType.Code} ${OIDCResponseType.Token}`,
+  `${OIDCResponseType.IdToken} ${OIDCResponseType.Token} ${OIDCResponseType.Code}`,
+];

--- a/tests/unit/authorize.test.ts
+++ b/tests/unit/authorize.test.ts
@@ -44,39 +44,27 @@ const testAuthorize = async (
 
 describe("/authorize response_types and response_modes", () => {
   const validTestCases = [
-    {
-      responseType: "code", // Authorization Code Flow
+    // Authorization Code Flow
+    ...AUTHORIZE_CODE_RESPONSE_TYPES.map((responseType) => ({
+      responseType,
       responseModes: [
         OIDCResponseMode.Query,
         OIDCResponseMode.Fragment,
         OIDCResponseMode.FormPost,
       ],
-    },
+    })),
 
-    {
-      responseType: "id_token", // Implicit Flow
+    // Implicit Flow
+    ...IMPLICIT_RESPONSE_TYPES.map((responseType) => ({
+      responseType,
       responseModes: [OIDCResponseMode.Fragment, OIDCResponseMode.FormPost],
-    },
+    })),
 
-    {
-      responseType: "id_token token", // Implicit Flow
+    // Hybrid Flow
+    ...HYBRID_RESPONSE_TYPES.map((responseType) => ({
+      responseType,
       responseModes: [OIDCResponseMode.Fragment, OIDCResponseMode.FormPost],
-    },
-
-    {
-      responseType: "code id_token", // Hybrid Flow
-      responseModes: [OIDCResponseMode.Fragment, OIDCResponseMode.FormPost],
-    },
-
-    {
-      responseType: "code token", // Hybrid Flow
-      responseModes: [OIDCResponseMode.Fragment, OIDCResponseMode.FormPost],
-    },
-
-    {
-      responseType: "code id_token token", // Hybrid Flow
-      responseModes: [OIDCResponseMode.Fragment, OIDCResponseMode.FormPost],
-    },
+    })),
 
     {
       responseType: "token", // Not directly part of OIDC (OAuth 2.0)

--- a/tests/unit/check-flow-type.test.ts
+++ b/tests/unit/check-flow-type.test.ts
@@ -1,37 +1,27 @@
 import { checkFlowType } from "@/api-helpers/utils";
 import { OIDCFlowType } from "@/types";
 
+import {
+  AUTHORIZE_CODE_RESPONSE_TYPES,
+  HYBRID_RESPONSE_TYPES,
+  IMPLICIT_RESPONSE_TYPES,
+} from "tests/__mocks__/authenticate.mock";
+
 describe("Check flow type", () => {
   test("Detects authorization code flow", () => {
-    const validResponseTypes = ["code"];
-
-    validResponseTypes.forEach((responseType) => {
+    AUTHORIZE_CODE_RESPONSE_TYPES.forEach((responseType) => {
       expect(checkFlowType(responseType)).toBe(OIDCFlowType.AuthorizationCode);
     });
   });
 
   test("Detects implicit flow", () => {
-    const validResponseTypes = ["token id_token", "id_token token", "id_token"];
-    validResponseTypes.forEach((responseType) => {
+    IMPLICIT_RESPONSE_TYPES.forEach((responseType) => {
       expect(checkFlowType(responseType)).toBe(OIDCFlowType.Implicit);
     });
   });
 
   test("Detects hybrid flow", () => {
-    const validResponseTypes = [
-      "code id_token",
-      "id_token code",
-      "code token",
-      "token code",
-      "code id_token token",
-      "code token id_token",
-      "token code id_token",
-      "token id_token code",
-      "id_token code token",
-      "id_token token code",
-    ];
-
-    validResponseTypes.forEach((responseType) => {
+    HYBRID_RESPONSE_TYPES.forEach((responseType) => {
       expect(checkFlowType(responseType)).toBe(OIDCFlowType.Hybrid);
     });
   });


### PR DESCRIPTION
Closes [this](https://github.com/worldcoin/world-id-sign-in/pull/38#discussion_r1304917955) comment

About [this](https://github.com/worldcoin/world-id-sign-in/pull/38#discussion_r1304918911) comment: 
- I think we already have it [here](https://github.com/worldcoin/world-id-sign-in/blob/authorize-tests/tests/unit/authorize.test.ts#L108). Or am I missing something? @paolodamico 