### PR TITLE
refactor: unify response_mode validation

### DIFF
--- a/src/api-helpers/validation.ts
+++ b/src/api-helpers/validation.ts
@@ -1,0 +1,26 @@
+import { OIDCResponseMode, OIDCResponseType } from "@/types";
+import * as yup from "yup";
+
+export const OIDCResponseModeValidation = yup
+  .string<OIDCResponseMode>()
+  .when("response_type", {
+    is: OIDCResponseType.Code,
+    // REFERENCE: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
+    then: (schema) => schema.default(OIDCResponseMode.Query),
+    otherwise: (schema) => schema.default(OIDCResponseMode.Fragment),
+  })
+  .test({
+    name: "is-valid-response-mode",
+    message: "Invalid response mode.",
+    test: (value) => {
+      if (!value) {
+        return true;
+      }
+
+      if (!(Object.values(OIDCResponseMode) as string[]).includes(value)) {
+        return false;
+      }
+
+      return true;
+    },
+  }) as yup.StringSchema<OIDCResponseMode, yup.AnyObject, undefined, "">;

--- a/src/app/authenticate/route.ts
+++ b/src/app/authenticate/route.ts
@@ -4,6 +4,7 @@ import { DEVELOPER_PORTAL } from "@/consts";
 import * as yup from "yup";
 import { validateRequestSchema } from "@/api-helpers/utils";
 import { OIDCResponseMode, ValidationMessage } from "@/types";
+import { OIDCResponseModeValidation } from "@/api-helpers/validation";
 
 const schema = yup.object({
   proof: yup.string().required(ValidationMessage.Required),
@@ -15,7 +16,7 @@ const schema = yup.object({
   scope: yup.string().required("The openid scope is always required."), // NOTE: Content verified in the Developer Portal
   state: yup.string(),
   response_type: yup.string().required(ValidationMessage.Required), // NOTE: Content verified in the Developer Portal
-  response_mode: yup.string().required(ValidationMessage.Required),
+  response_mode: OIDCResponseModeValidation,
   redirect_uri: yup.string().required(ValidationMessage.Required), // NOTE: Content verified in the Developer Portal
 });
 

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -10,6 +10,7 @@ import {
 import { errorValidationClient } from "@/api-helpers/errors";
 import * as yup from "yup";
 import { checkFlowType, validateRequestSchema } from "@/api-helpers/utils";
+import { OIDCResponseModeValidation } from "@/api-helpers/validation";
 
 enum OIDCScope {
   OpenID = "openid",
@@ -74,29 +75,7 @@ const schema = yup.object({
     then: (field) => field.required(ValidationMessage.Required),
   }),
 
-  response_mode: yup
-    .string<OIDCResponseMode>()
-    .when("response_type", {
-      is: OIDCResponseType.Code,
-      // REFERENCE: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
-      then: (schema) => schema.default(OIDCResponseMode.Query),
-      otherwise: (schema) => schema.default(OIDCResponseMode.Fragment),
-    })
-    .test({
-      name: "is-valid-response-mode",
-      message: "Invalid response mode.",
-      test: (value) => {
-        if (!value) {
-          return true;
-        }
-
-        if (!(Object.values(OIDCResponseMode) as string[]).includes(value)) {
-          return false;
-        }
-
-        return true;
-      },
-    }),
+  response_mode: OIDCResponseModeValidation,
 });
 
 // FIXME: should we add a CSRF token to the request?


### PR DESCRIPTION
Closes [WID-536](https://linear.app/worldcoin/issue/WID-536/response-mode-validation-should-also-be-enforced-in-the-authenticate)

- Moves common validation code to `/lib/validation`
- Applies common validation to the both endpoints  