### PR TITLE
fix: default response_mode in native sign in

### DIFF
--- a/src/app/v1/mobile-auth/route.ts
+++ b/src/app/v1/mobile-auth/route.ts
@@ -42,7 +42,7 @@ export const POST = async (req: NextRequest): Promise<NextResponse> => {
 
   if (parsedParams.response_mode === OIDCResponseMode.Query) {
     redirect_uri.search = result.url_params.toString();
-  } else if (parsedParams.response_mode === OIDCResponseMode.Fragment) {
+  } else {
     redirect_uri.hash = result.url_params.toString();
   }
 


### PR DESCRIPTION
By default `response_mode = fragment`, this reflects such handling.