### PR TITLE
fix: nonce handling

### DIFF
--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -164,13 +164,12 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
     response_mode,
     client_id,
     redirect_uri,
-    nonce: nonce || new Date().getTime().toString(), // NOTE: given the nature of our proofs, if a nonce is not passed, we generate one
-    // TODO: should enforce one time use for nonces
+    scope,
     ready: "true", // for UX purposes, to avoid users getting to the login page without verifying their request
   });
 
-  if (scope) {
-    params.append("scope", scope.toString());
+  if (nonce) {
+    params.append("nonce", nonce.toString());
   }
 
   if (state) {

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -55,10 +55,10 @@ const schema = yup.object({
     }),
   state: yup.string(),
   nonce: yup.string().when("response_type", {
-    // NOTE: we only require a nonce for the implicit flow
-    is: (value: string) =>
-      checkFlowType(decodeURIComponent(value)) === OIDCFlowType.Implicit,
-    then: (field) => field.required(ValidationMessage.Required),
+    is: (response_type: string) =>
+      ["code", "code token"].includes(response_type),
+    then: (nonce) => nonce.optional(),
+    otherwise: (nonce) => nonce.required(ValidationMessage.Required),
   }),
   response_mode: OIDCResponseModeValidation,
   code_challenge: yup.string().when("code_challenge_method", {

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -25,7 +25,11 @@ export const authenticateSchema = yup.object({
   // TODO: Remove in favor of verification_level once it's supported in all app versions
   credential_type: yup.string().oneOf(Object.values(CredentialType)),
   client_id: yup.string().required(ValidationMessage.Required),
-  nonce: yup.string().required(ValidationMessage.Required), // NOTE: While technically not required by the OIDC spec, we require it as a security best practice
+  nonce: yup.string().when("response_type", {
+    is: "code",
+    then: (nonce) => nonce.optional(),
+    otherwise: (nonce) => nonce.required(ValidationMessage.Required),
+  }),
   scope: yup.string().required("The openid scope is always required."), // NOTE: Content verified in the Developer Portal
   state: yup.string(),
   response_type: yup.string().required(ValidationMessage.Required), // NOTE: Content verified in the Developer Portal

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -26,7 +26,8 @@ export const authenticateSchema = yup.object({
   credential_type: yup.string().oneOf(Object.values(CredentialType)),
   client_id: yup.string().required(ValidationMessage.Required),
   nonce: yup.string().when("response_type", {
-    is: "code",
+    is: (response_type: string) =>
+      ["code", "code token"].includes(response_type),
     then: (nonce) => nonce.optional(),
     otherwise: (nonce) => nonce.required(ValidationMessage.Required),
   }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface IAuthorizeRequest {
   redirect_uri: string;
   response_type: string;
   response_mode?: OIDCResponseMode;
-  nonce: string;
+  nonce?: string;
   scope?: string;
   state?: string;
 }

--- a/tests/unit/authorize.test.ts
+++ b/tests/unit/authorize.test.ts
@@ -9,7 +9,7 @@ import {
   IMPLICIT_RESPONSE_TYPES,
 } from "tests/__mocks__/authenticate.mock";
 
-import { OIDCResponseMode } from "@/types";
+import { OIDCResponseMode, OIDCResponseType } from "@/types";
 import { OIDCErrorCodes } from "@/api-helpers/errors";
 
 beforeAll(() => {
@@ -141,12 +141,17 @@ describe("/authorize response_types and response_modes", () => {
 });
 
 describe("/authorize nonce", () => {
-  const responseTypesWithNonce = IMPLICIT_RESPONSE_TYPES;
-
   const responseTypesWithoutNonce = [
-    ...AUTHORIZE_CODE_RESPONSE_TYPES,
-    ...HYBRID_RESPONSE_TYPES,
+    // only 'code' and 'code token' response types do not require nonce per OIDC Spec 3.1.2.1 and 3.3.2.1
+    `${OIDCResponseType.Code}`,
+    `${OIDCResponseType.Code} ${OIDCResponseType.Token}`,
   ];
+
+  const responseTypesWithNonce = [
+    // All other response types require nonce
+    ...IMPLICIT_RESPONSE_TYPES,
+    ...HYBRID_RESPONSE_TYPES,
+  ].filter((responseType) => !responseTypesWithoutNonce.includes(responseType));
 
   for (const response_type of responseTypesWithNonce) {
     test(`Nonce required for implicit flow | response_type: ${response_type}`, async () => {


### PR DESCRIPTION
makes `nonce` optional when `response_type` is `code` or `code token`, and removes generation of nonce when one is not provided