### PR TITLE
feat: redirect authorize to download if on mobile

### DIFF
--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -77,10 +77,7 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
     (req.headers.get("user-agent")?.includes("iPhone") ||
       req.headers.get("user-agent")?.includes("Android"))
   ) {
-    return NextResponse.redirect(
-      "https://worldcoin.org/download?worldid=true",
-      {}
-    );
+    return NextResponse.redirect("https://worldcoin.org/download?worldid=true");
   }
 
   const { parsedParams, isValid, errorResponse } = await validateRequestSchema({

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -72,6 +72,17 @@ const schema = yup.object({
 });
 
 export const GET = async (req: NextRequest): Promise<NextResponse> => {
+  if (
+    req.headers.get("user-agent")?.includes("Mobile") &&
+    (req.headers.get("user-agent")?.includes("iPhone") ||
+      req.headers.get("user-agent")?.includes("Android"))
+  ) {
+    return NextResponse.redirect(
+      "https://worldcoin.org/download?worldid=true",
+      {}
+    );
+  }
+
   const { parsedParams, isValid, errorResponse } = await validateRequestSchema({
     schema,
     req,


### PR DESCRIPTION
redirects users to the World App download page (with a subsequent redirect to the correct app store) if they visit id.worldcoin.org/authorize from a mobile device

opening id.worldcoin.org/authorize on mobile should ALWAYS open the app directly and completely avoid the flow using the bridge, so if the app is not installed it is safe to direct to the download page

caveat: some android tablets may be detected as mobile devices by the user-agent header. this can be bypassed with the "Request Desktop Site" feature of any mobile web browser.