### PR TITLE
fix: handle null or empty string response mode

### DIFF
--- a/src/api-helpers/validation.ts
+++ b/src/api-helpers/validation.ts
@@ -4,6 +4,8 @@ import * as yup from "yup";
 
 export const OIDCResponseModeValidation = yup
   .string<OIDCResponseMode>()
+  .ensure() // cast null and undefined to "", for next step
+  .transform((value) => (value === "" ? undefined : value)) // transform "" to undefined, so default applies
   .when("response_type", {
     is: OIDCResponseType.Code,
     // REFERENCE: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html


### PR DESCRIPTION
Handles `null` or `""` as values for `/v1/mobile-auth` inputs properly by casting them to undefined and applying the default value. (Hopefully) fixes an issue present with Android native World ID sign-in.

My suspicion:
- Android app sends request to `/v1/mobile-auth` with `response_mode` as `null`
- Yup default is not applied, as they only apply when value is `undefined`
- Test statement passes, as it returns true when `!value`
- `/v1/mobile-auth/route.ts` checks `parsedParams.response_mode === OIDCResponseMode.Query`, which is false, as `response_mode` is `null`, so it uses fragment response mode in response to World App