### PR TITLE
fix: handle empty response mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 
 # TODO: Version tagging
 # TODO: Can be further optimized to remove next peer dependency
-RUN yarn add next-logger dd-trace
+RUN yarn add next-logger dd-trace@5.12.0
 
 # Rebuild the source code only when needed
 FROM base AS builder

--- a/src/api-helpers/utils.ts
+++ b/src/api-helpers/utils.ts
@@ -47,19 +47,7 @@ export const validateRequestSchema = async <T extends yup.Schema>({
       }
     }
 
-    console.log("pre yup validation response_type: ", rawParams.response_type);
-    console.log("pre yup validation response_mode: ", rawParams.response_mode);
-
     parsedParams = await schema.validate(rawParams);
-
-    console.log(
-      "post yup validation response_type: ",
-      parsedParams.response_type
-    );
-    console.log(
-      "post yup validation response_mode: ",
-      parsedParams.response_mode
-    );
   } catch (error) {
     if (error instanceof yup.ValidationError) {
       const code = OIDCErrorCodes.InvalidRequest;

--- a/src/api-helpers/validation.ts
+++ b/src/api-helpers/validation.ts
@@ -4,12 +4,16 @@ import * as yup from "yup";
 
 export const OIDCResponseModeValidation = yup
   .string<OIDCResponseMode>()
+  .nullable() // we might as well allow null since we'll handle it properly
+  .ensure() // cast null and undefined to "", for next step
+  .transform((value) => (value === "" ? undefined : value)) // transform "" to undefined, so default applies
   .when("response_type", {
     is: OIDCResponseType.Code,
     // REFERENCE: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
     then: (schema) => schema.default(OIDCResponseMode.Query),
     otherwise: (schema) => schema.default(OIDCResponseMode.Fragment),
   })
+  .oneOf(Object.values(OIDCResponseMode))
   .test({
     name: "is-valid-response-mode",
     message: "Invalid response mode.",


### PR DESCRIPTION
allows undefined, null, and "" values for response_mode to be properly handled and use the default based on the response_type

the earlier bug was an issue in dd-trace v5.11.0, and when we rolled back, we somehow ended up with v5.12.0 (containing the fix) getting released in the 4 minutes between the staging and prod deploys, so staging still didn't work, but prod did

wack