### PR TITLE
feat: authorize-web endpoint

### DIFF
--- a/src/app/authorize-web/route.ts
+++ b/src/app/authorize-web/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export const GET = async (req: NextRequest): Promise<NextResponse> => {
+  let url = new URL(req.url);
+  url.pathname = "/authorize";
+
+  let res = NextResponse.redirect(url, {
+    status: 303,
+    headers: { "Set-Cookie": `web-only=true` },
+  });
+
+  return res;
+};

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -73,6 +73,7 @@ const schema = yup.object({
 
 export const GET = async (req: NextRequest): Promise<NextResponse> => {
   if (
+    !req.cookies.get("web-only") &&
     req.headers.get("user-agent")?.includes("Mobile") &&
     (req.headers.get("user-agent")?.includes("iPhone") ||
       req.headers.get("user-agent")?.includes("Android"))


### PR DESCRIPTION
Adds the `/authorize-web` endpoint, which allows third-party applications using Sign In with World ID to choose the bridge flow as opposed to the mobile-native flow.

Applications that wish to always use the bridge flow can simply replace `id.worldcoin.org/authorize?client_id=app_...` with <code>id.worldcoin.org/**authorize-web**?client_id=app_...</code>.

This PR is prompted by a specific integration of Sign In with World ID which uses ICP's Internet Identity, which by design requires that the `redirect_uri` be visited from the same tab that initiated the sign in process. The mobile-native flow will always open the `redirect_uri` in a new tab due to iOS/Android limitations, and this method is intended as a workaround.