### PR TITLE
fix: use public url for authorize-web redirect

### DIFF
--- a/src/app/authorize-web/route.ts
+++ b/src/app/authorize-web/route.ts
@@ -2,8 +2,8 @@ import { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export const GET = async (req: NextRequest): Promise<NextResponse> => {
-  let url = new URL(req.url);
-  url.pathname = "/authorize";
+  let url = new URL("/authorize", process.env.NEXT_PUBLIC_URL);
+  url.search = new URL(req.url).searchParams.toString();
 
   let res = NextResponse.redirect(url, {
     status: 303,


### PR DESCRIPTION
was redirecting to AWS internal URL