### PR TITLE
fix: don't auto-open world app on mobile

### DIFF
--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -155,7 +155,7 @@ const IDKitQR: FC<Props> = ({
         VerificationState.Confirmed,
       ].includes(wcStage) && (
         <>
-          <div className="text-center text-gray-400 mt-2">or</div>
+          {/* <div className="text-center text-gray-400 mt-2">or</div> */}
           <a
             href={deeplink ? deeplink : "https://worldcoin.org/download"}
             rel="noreferrer noopener"

--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -115,7 +115,7 @@ const IDKitQR: FC<Props> = ({
       ></form>
       <Header
         meta={app_data}
-        className="md:hidden"
+        className="md:hidden flex flex-col items-center "
         headerShown={
           ![
             VerificationState.WaitingForApp,

--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -165,8 +165,10 @@ const IDKitQR: FC<Props> = ({
               <div className="bg-text rounded p-1 mr-2">
                 <IconWorldcoin className="text-white text-sm" />
               </div>
-              <div className="flex-grow hidden md:block">Manually open app</div>
-              <div className="flex-grow md:hidden">Sign up in the app</div>
+              <div className="flex-grow md:hidden">Manually open World App</div>
+              <div className="flex-grow hidden md:block">
+                Sign up in World App
+              </div>
               <IconArrowRight className="text-2xl text-gray-400" />
             </div>
           </a>

--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -155,7 +155,6 @@ const IDKitQR: FC<Props> = ({
         VerificationState.Confirmed,
       ].includes(wcStage) && (
         <>
-          {/* <div className="text-center text-gray-400 mt-2">or</div> */}
           <a
             href={deeplink ? deeplink : "https://worldcoin.org/download"}
             rel="noreferrer noopener"

--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -216,8 +216,11 @@ const Header = ({
           </div>
         </div>
       </div>
-      <div className="text-xl md:text-2xl mt-2 text-center font-semibold font-sora max-w-[350px]">
-        <Balancer>Scan with World App to continue to {meta?.name}</Balancer>
+      <div className="hidden md:block text-xl md:text-2xl mt-2 text-center font-semibold font-sora max-w-[350px]">
+        <Balancer>Scan with World App to sign in to {meta?.name}</Balancer>
+      </div>
+      <div className="md:hidden block text-xl md:text-2xl mt-2 text-center font-semibold font-sora max-w-[350px]">
+        <Balancer>Use World App to sign in to {meta?.name}</Balancer>
       </div>
     </div>
   ) : null;

--- a/src/components/IDKitBridge.tsx
+++ b/src/components/IDKitBridge.tsx
@@ -220,7 +220,7 @@ const IDKitBridge = ({
                 <Spinner />
 
                 <div className="text-text-muted pt-4">
-                  Wait a few seconds, automatically opening World App
+                  Waiting for connection to World App...
                 </div>
               </div>
             </>

--- a/src/components/IDKitBridge.tsx
+++ b/src/components/IDKitBridge.tsx
@@ -119,12 +119,6 @@ const IDKitBridge = ({
   ]);
 
   useEffect(() => {
-    const isMobile = window.matchMedia("(max-width: 768px)").matches; // to use the same logic as UI (Tailwind)
-
-    if (isMobile && connectorURI) {
-      window.open(connectorURI, "_blank", "noopener,noreferrer");
-    }
-
     if (connectorURI) {
       setDeeplink(connectorURI);
     }


### PR DESCRIPTION
Mobile platforms will not treat an automatic new tab open as a deeplink, it must be prompted by a user action. This PR removes the auto-open functionality and adjusts copy accordingly, as well as a few small visual fixes on mobile platforms.