### PR TITLE
feat: authorize-web refactor

### DIFF
--- a/src/app/authorize-web/route.ts
+++ b/src/app/authorize-web/route.ts
@@ -1,14 +1,2 @@
-import { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-
-export const GET = async (req: NextRequest): Promise<NextResponse> => {
-  let url = new URL("/authorize", process.env.NEXT_PUBLIC_URL);
-  url.search = new URL(req.url).searchParams.toString();
-
-  let res = NextResponse.redirect(url, {
-    status: 303,
-    headers: { "Set-Cookie": `web-only=true` },
-  });
-
-  return res;
-};
+// only purpose here is to avoid deeplinking to World App if this url is used
+export { GET } from "../authorize/route";

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -73,7 +73,6 @@ const schema = yup.object({
 
 export const GET = async (req: NextRequest): Promise<NextResponse> => {
   if (
-    !req.cookies.get("web-only") &&
     req.headers.get("user-agent")?.includes("Mobile") &&
     (req.headers.get("user-agent")?.includes("iPhone") ||
       req.headers.get("user-agent")?.includes("Android"))


### PR DESCRIPTION
Refactors the `/authorize-web` endpoint to simply re-export `/authorize`. This means that a redirect to `/authorize` is bypassed when using `/authorize-web`, preventing opening World App via deeplink.