### PR TITLE
ui bug fixes

### DIFF
--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -104,7 +104,6 @@ const IDKitQR: FC<Props> = ({
       code_challenge_method,
     ]
   );
-
   return (
     <>
       <form
@@ -201,7 +200,7 @@ const Header = ({
           ) : (
             <p className="text-xl tracking-wider">
               {meta?.name
-                .split(" ")
+                ?.split(" ")
                 .map((word) => word[0])
                 .join("")}
             </p>
@@ -215,7 +214,7 @@ const Header = ({
           </div>
         </div>
       </div>
-      <div className="hidden md:block text-xl md:text-2xl mt-2 text-center font-semibold font-sora max-w-[350px]">
+      <div className="hidden md:block text-xl md:text-2xl mt-2 text-center font-semibold font-sora max-w-[350px] break-words">
         <Balancer>Scan with World App to sign in to {meta?.name}</Balancer>
       </div>
       <div className="md:hidden block text-xl md:text-2xl mt-2 text-center font-semibold font-sora max-w-[350px]">

--- a/src/components/IDKitBridge.tsx
+++ b/src/components/IDKitBridge.tsx
@@ -11,6 +11,7 @@ import {
   IDKitConfig,
   VerificationLevel,
 } from "@worldcoin/idkit-core";
+import clsx from "clsx";
 
 interface IIDKitBridge {
   nonce: string;
@@ -28,6 +29,8 @@ const IDKitBridge = ({
   setDeeplink,
 }: IIDKitBridge): JSX.Element => {
   const [intervalId, setIntervalId] = useState<NodeJS.Timer | null>(null);
+  const isMobileDevice = () =>
+    /iPhone|iPad|iPod|Android|Mobile/i.test(navigator.userAgent);
 
   const {
     createClient,
@@ -148,7 +151,9 @@ const IDKitBridge = ({
                 <>
                   {/* .qr-code className used for remote synthetic tests */}
                   <div
-                    className="hidden md:block qr-code cursor-pointer"
+                    className={clsx("qr-code cursor-pointer max-md:mt-8", {
+                      hidden: isMobileDevice(),
+                    })}
                     onClick={copyLink}
                   >
                     <QRCode data={connectorURI} size={280} />
@@ -210,13 +215,21 @@ const IDKitBridge = ({
               ) : (
                 <>
                   {/* .qr-code className used for remote synthetic tests */}
-                  <div className="hidden md:block qr-code">
+                  <div
+                    className={clsx("qr-code max-md:mt-8", {
+                      hidden: isMobileDevice(),
+                    })}
+                  >
                     <QRCode data={connectorURI} size={280} />
                   </div>
                 </>
               )}
 
-              <div className="md:hidden mt-10 md:mt-0">
+              <div
+                className={clsx("mt-10 md:mt-0", {
+                  hidden: !isMobileDevice(),
+                })}
+              >
                 <Spinner />
 
                 <div className="text-text-muted pt-4">


### PR DESCRIPTION
<img width="1182" alt="Screenshot 2024-07-24 at 1 37 37 PM" src="https://github.com/user-attachments/assets/3227246f-aa15-4f6a-acfc-eac551b446c8">

If the screen is too small the QR code is gone. Fix this by user agents instead
if name is too long it was extending out of the modal