### PR TITLE
Improve Mobile Sign In

### DIFF
--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 
 import { IconBadge, IconBadgeX, IconWorldcoin } from "@/components/icons";
 import { DEVELOPER_PORTAL } from "@/consts";
+import clsx from "clsx";
 
 type Meta = {
   name: string;
@@ -57,6 +58,8 @@ const IDKitQR: FC<Props> = ({
   const [wcStage, setWCStage] = useState<VerificationState>(
     VerificationState.PreparingClient
   );
+  const isMobileDevice = () =>
+    /iPhone|iPad|iPod|Android|Mobile/i.test(navigator.userAgent);
 
   const handleIDKitSuccess = useCallback(
     async (result: ISuccessResult) => {
@@ -118,7 +121,12 @@ const IDKitQR: FC<Props> = ({
           ].includes(wcStage)
         }
       />
-      <div className="bg-white rounded-2xl w-full h-full mt-6 md:mt-0 md:min-w-[450px] md:min-h-[580px] max-h-[39rem] p-8 md:p-12 text-center flex flex-col justify-center items-center border border-gray-200 relative">
+      <div
+        className={clsx(
+          "bg-white rounded-2xl w-full h-full mt-6 md:mt-0 md:min-w-[450px] md:min-h-[580px] max-h-[39rem] p-8 md:p-12 text-center flex flex-col justify-center items-center border border-gray-200 relative",
+          { hidden: isMobileDevice() }
+        )}
+      >
         <div className="absolute top-0 inset-x-0 px-4 py-2 space-x-2 flex items-center border-b">
           <IconWorldcoin className="w-4 h-4" />
           <p className="text-sm font-rubik">Sign in with World ID</p>
@@ -143,6 +151,25 @@ const IDKitQR: FC<Props> = ({
           onSuccess={handleIDKitSuccess}
         />
       </div>
+      {![
+        VerificationState.WaitingForApp,
+        VerificationState.PreparingClient,
+        VerificationState.Confirmed,
+      ].includes(wcStage) && (
+        <>
+          <a
+            href={deeplink}
+            className={clsx("mt-3 md:mt-", {
+              hidden: !isMobileDevice(),
+            })}
+          >
+            <div className="bg-black rounded-lg mt-2 px-8 py-4 gap-x-4 flex items-center border border-gray-200 cursor-pointer">
+              <IconWorldcoin className="text-white text-sm" />
+              <p className="text-white">Continue in World App</p>
+            </div>
+          </a>
+        </>
+      )}
     </>
   );
 };

--- a/src/app/login/ClientPage.tsx
+++ b/src/app/login/ClientPage.tsx
@@ -7,12 +7,7 @@ import { VerificationState, ISuccessResult } from "@worldcoin/idkit-core";
 import IDKitBridge from "@/components/IDKitBridge";
 import Image from "next/image";
 
-import {
-  IconArrowRight,
-  IconBadge,
-  IconBadgeX,
-  IconWorldcoin,
-} from "@/components/icons";
+import { IconBadge, IconBadgeX, IconWorldcoin } from "@/components/icons";
 import { DEVELOPER_PORTAL } from "@/consts";
 
 type Meta = {
@@ -148,30 +143,6 @@ const IDKitQR: FC<Props> = ({
           onSuccess={handleIDKitSuccess}
         />
       </div>
-      {![
-        VerificationState.WaitingForApp,
-        VerificationState.PreparingClient,
-        VerificationState.Confirmed,
-      ].includes(wcStage) && (
-        <>
-          <a
-            href={deeplink ? deeplink : "https://worldcoin.org/download"}
-            rel="noreferrer noopener"
-            target="_blank"
-          >
-            <div className="bg-white rounded-lg mt-2 px-4 py-3 flex items-center border border-gray-200 cursor-pointer">
-              <div className="bg-text rounded p-1 mr-2">
-                <IconWorldcoin className="text-white text-sm" />
-              </div>
-              <div className="flex-grow md:hidden">Manually open World App</div>
-              <div className="flex-grow hidden md:block">
-                Sign up in World App
-              </div>
-              <IconArrowRight className="text-2xl text-gray-400" />
-            </div>
-          </a>
-        </>
-      )}
     </>
   );
 };

--- a/src/components/IDKitBridge.tsx
+++ b/src/components/IDKitBridge.tsx
@@ -12,7 +12,6 @@ import {
   VerificationLevel,
 } from "@worldcoin/idkit-core";
 import clsx from "clsx";
-import { IconWorldcoin } from "./icons";
 
 interface IIDKitBridge {
   nonce: string;
@@ -225,18 +224,6 @@ const IDKitBridge = ({
                   </div>
                 </>
               )}
-
-              <a
-                href={connectorURI}
-                className={clsx("mt-3 md:mt-", {
-                  hidden: !isMobileDevice(),
-                })}
-              >
-                <div className="bg-black rounded-lg mt-2 px-8 py-4 gap-x-4 flex items-center border border-gray-200 cursor-pointer">
-                  <IconWorldcoin className="text-white text-sm" />
-                  <p className="text-white">Continue in World App</p>
-                </div>
-              </a>
             </>
           )}
         </>

--- a/src/components/IDKitBridge.tsx
+++ b/src/components/IDKitBridge.tsx
@@ -12,6 +12,7 @@ import {
   VerificationLevel,
 } from "@worldcoin/idkit-core";
 import clsx from "clsx";
+import { IconWorldcoin } from "./icons";
 
 interface IIDKitBridge {
   nonce: string;
@@ -140,7 +141,7 @@ const IDKitBridge = ({
   }, [connectorURI, isStaging]);
 
   return (
-    <div className="md:mt-8">
+    <div className="md:mt-8 mt-7">
       {verificationState === VerificationState.WaitingForConnection && (
         <>
           {!connectorURI && <Spinner />}
@@ -225,17 +226,17 @@ const IDKitBridge = ({
                 </>
               )}
 
-              <div
-                className={clsx("mt-10 md:mt-0", {
+              <a
+                href={connectorURI}
+                className={clsx("mt-3 md:mt-", {
                   hidden: !isMobileDevice(),
                 })}
               >
-                <Spinner />
-
-                <div className="text-text-muted pt-4">
-                  Waiting for connection to World App...
+                <div className="bg-black rounded-lg mt-2 px-8 py-4 gap-x-4 flex items-center border border-gray-200 cursor-pointer">
+                  <IconWorldcoin className="text-white text-sm" />
+                  <p className="text-white">Continue in World App</p>
                 </div>
-              </div>
+              </a>
             </>
           )}
         </>
@@ -247,7 +248,7 @@ const IDKitBridge = ({
 
           {verificationState === VerificationState.PreparingClient && (
             <>
-              <h1 className="font-medium text-3xl mt-12">Loading...</h1>
+              <h1 className="font-medium text-3xl md:mt-12 mt-4">Loading...</h1>
               <div className="text-text-muted text-xl mt-2">
                 Please wait a moment
               </div>


### PR DESCRIPTION
I remove the manual button we had before since I believe all situations we should account for are covered by the new button. This will improve the visual flow when we have to trigger a manual sign in and cannot automatically open the universal link -> redirect

<img width="305" alt="Screenshot 2024-07-25 at 6 29 21 PM" src="https://github.com/user-attachments/assets/a2eee65e-c9dc-4eb1-8e7a-b2c115b48d63">
