### PR TITLE
fix: default to "" nonce when not required

### DIFF
--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -54,13 +54,15 @@ const schema = yup.object({
       },
     }),
   state: yup.string(),
-  nonce: yup.string().when("response_type", {
-    // NOTE: we only require a nonce for the implicit flow
-    is: (value: string) =>
-      checkFlowType(decodeURIComponent(value)) === OIDCFlowType.Implicit,
-    then: (field) => field.required(ValidationMessage.Required),
-    otherwise: (field) => field.default(""),
-  }),
+  nonce: yup
+    .string()
+    .ensure()
+    .when("response_type", {
+      // NOTE: we only require a nonce for the implicit flow
+      is: (value: string) =>
+        checkFlowType(decodeURIComponent(value)) === OIDCFlowType.Implicit,
+      then: (field) => field.required(ValidationMessage.Required),
+    }),
   response_mode: OIDCResponseModeValidation,
   code_challenge: yup.string().when("code_challenge_method", {
     is: (value: string) => Boolean(value),

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -59,6 +59,7 @@ const schema = yup.object({
     is: (value: string) =>
       checkFlowType(decodeURIComponent(value)) === OIDCFlowType.Implicit,
     then: (field) => field.required(ValidationMessage.Required),
+    otherwise: (field) => field.default(""),
   }),
   response_mode: OIDCResponseModeValidation,
   code_challenge: yup.string().when("code_challenge_method", {

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -25,14 +25,17 @@ export const authenticateSchema = yup.object({
   // TODO: Remove in favor of verification_level once it's supported in all app versions
   credential_type: yup.string().oneOf(Object.values(CredentialType)),
   client_id: yup.string().required(ValidationMessage.Required),
-  nonce: yup.string().when("response_type", {
-    is: (response_type: string) =>
-      !["code", "code token"].includes(response_type),
-    then: (nonce) =>
-      nonce.required(
-        "`nonce` required for all response types except `code` and `code token`."
-      ),
-  }), // NOTE: nonce is required for all response types except `code` and `code token`
+  nonce: yup
+    .string()
+    .ensure()
+    .when("response_type", {
+      is: (response_type: string) =>
+        !["code", "code token"].includes(response_type),
+      then: (nonce) =>
+        nonce.required(
+          "`nonce` required for all response types except `code` and `code token`."
+        ),
+    }), // NOTE: nonce is required for all response types except `code` and `code token`
   scope: yup
     .string()
     .transform((string) => string.replace(/\+/g, "%20")) // NOTE: Replaces '+' with '%20' so Developer Portal can parse the scope(s) correctly


### PR DESCRIPTION
developer portal expects a signal value to be provided, and throws an error when one is not provided. this updates yup validation to cast undefined and null nonce values to `""` using `.ensure()`, which will fail validation when nonce is required, but otherwise will provide a value to the developer portal to avoid errors