### PR TITLE
feat: allow base64 chars

### DIFF
--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -43,7 +43,7 @@ export const authenticateSchema = yup.object({
   state: yup
     .string()
     .ensure() // undefined or null values are coerced to empty strings, to pass the regex validation
-    .matches(/^[a-zA-Z0-9,._-]{0,256}$/, {
+    .matches(/^[a-zA-Z0-9,._+-/=]{0,256}$/, {
       message:
         "State parameter must be 256 characters or less and contain only alphanumeric, comma, period, underscore, and hyphen characters.",
     }),


### PR DESCRIPTION
Allows `state` param to include all valid Base64 characters, since Auth0 SPA SDK uses Base64-encoded value for the state by default.