### PR TITLE
fix: Fix DataDog resource names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=server_deps --chown=nextjs:nodejs /app/node_modules/. ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Source maps are enabled to provide helpful error stacks
-ENV NODE_OPTIONS='--enable-source-maps -r dd-trace/init -r next-logger'
+ENV NODE_OPTIONS='--enable-source-maps -r dd-trace -r next-logger'
 ENV NODE_ENV production
 
 # Final config

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
       config.externals.push({
         "utf-8-validate": "utf-8-validate",
         bufferutil: "bufferutil",
+        "dd-trace": "dd-trace",
       });
       // NOTE: enables server-side source maps for debugging
       config.devtool = "source-map";
@@ -16,6 +17,11 @@ const nextConfig = {
     return config;
   },
   reactStrictMode: true,
+  experimental: {
+    instrumentationHook: true,
+    serverComponentsExternalPackages: ["winston"],
+  },
+
   async rewrites() {
     return [
       ...OIDC_ROUTES.map((route) => ({

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+
+export async function register() {
+  console.log("🛠️ Starting Instrumentation registration...");
+
+  try {
+    if (
+      typeof window === "undefined" &&
+      process.env.NEXT_RUNTIME === "nodejs"
+    ) {
+      console.log("Registering dd-trace");
+
+      const ddTrace = await import("dd-trace");
+
+      const tracer = ddTrace.default.init({
+        profiling: true,
+        runtimeMetrics: true,
+        logInjection: true,
+      });
+
+      // Monitor Winston Logger
+      tracer.use("winston", {
+        enabled: true,
+      });
+
+      // Monitor HTTP requests
+      tracer.use("http", {
+        hooks: {
+          request(span, req, res) {
+            if (span && req) {
+              const urlString = "path" in req ? req.path : req.url;
+
+              if (urlString) {
+                const url = new URL(urlString, "http://localhost");
+                const resourceGroup = url.pathname;
+                const method = req.method;
+
+                span.setTag(
+                  "resource.name",
+                  method ? `${method} ${resourceGroup}` : resourceGroup
+                );
+              }
+            }
+          },
+        },
+      });
+
+      // Disable the Next.js instrumentation as it creates duplicate spans
+      tracer.use("next", {
+        enabled: false,
+      });
+
+      console.log("dd-trace registered");
+    }
+  } catch (error) {
+    return console.error("🔴 Instrumentation registration error: ", error);
+  }
+
+  console.log("✅ Instrumentation registration complete.");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
Introduces a Next.js instrumentation registration.
Adds `dd-trace` initialization in the instrumentation file to monitor Winston Logger and HTTP requests.
Disables `next` plugin for DD to prevent duplicate spans.
✅ Tested in [staging](https://app.datadoghq.com/apm/traces?query=env%3Astaging%20service%3Aworld-id-sign-in&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&my_code=enabled&shouldShowLegend=true&sort=time&sort_by=%40http.status_code&sort_order=desc&spanType=all&spanViewType=metadata&storage=hot&traceQuery=&view=spans&start=1748525075063&end=1748526875063&paused=false)
