### PR TITLE
feat: Change runner to self-hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   lint:
     name: Code formatting & linting
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@v3
 
@@ -33,7 +34,8 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Migrates the CI runner to a high-availability self-hosted one.

